### PR TITLE
Fix RaceSelector closing bracket

### DIFF
--- a/components/RaceSelector.tsx
+++ b/components/RaceSelector.tsx
@@ -48,7 +48,7 @@ export function RaceSelector({
                             {`${session.circuit_short_name} - ${formattedDate}`}
                         </SelectItem>
                     );
-                })}
+                })
             </SelectContent>
         </Select>
     );


### PR DESCRIPTION
## Summary
- fix extra bracket in RaceSelector map callback

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68405b9ff89c832cb457e6898d4943b5