### PR TITLE
Fix RaceSelector export issue

### DIFF
--- a/components/DashBoardLayout.tsx
+++ b/components/DashBoardLayout.tsx
@@ -4,7 +4,7 @@
 
 import React, { useEffect, useState, createContext } from "react";
 import { Badge } from "@/components/ui/badge";
-import { RaceSelector } from "@/components/RaceSelector";
+import RaceSelector from "@/components/RaceSelector";
 import { getAvailableRaces, Session } from "@/lib/f1api";
 import { Progress } from "@/components/ui/progress"; // Importa Progress
 import Navbar from "@/components/Navbar";

--- a/components/RaceSelector.tsx
+++ b/components/RaceSelector.tsx
@@ -18,7 +18,7 @@ interface RaceSelectorProps {
     onSelectSession: (sessionKey: number) => void;
 }
 
-export function RaceSelector({
+export default function RaceSelector({
     sessions,
     selectedSessionKey,
     onSelectSession,
@@ -39,16 +39,21 @@ export function RaceSelector({
                 {sessions.map((session) => {
                     const date = new Date(session.date_start);
                     const day = date.getDate().toString().padStart(2, "0");
-                    const month = (date.getMonth() + 1).toString().padStart(2, "0"); // Mesi da 0 a 11
+                    const month = (date.getMonth() + 1)
+                        .toString()
+                        .padStart(2, "0"); // Mesi da 0 a 11
                     const year = date.getFullYear();
                     const formattedDate = `${day}/${month}/${year}`;
 
                     return (
-                        <SelectItem key={session.session_key} value={String(session.session_key)}>
+                        <SelectItem
+                            key={session.session_key}
+                            value={String(session.session_key)}
+                        >
                             {`${session.circuit_short_name} - ${formattedDate}`}
                         </SelectItem>
                     );
-                })
+                })}
             </SelectContent>
         </Select>
     );


### PR DESCRIPTION
## Summary
- export `RaceSelector` as default
- update `DashBoardLayout` to use the default export

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684060a8c1b4832c8ada8959ff128558